### PR TITLE
Include tree as obj to be parsed

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -16,7 +16,7 @@ const parseSchema = (schema) => {
     // parse Schema
     if (propertyType === 'Schema') { // normal schema
       let propSchema
-      if (hasOwnProperty(property, 'obj') || hasOwnProperty(property, 'type')) {
+      if (hasOwnProperty(property, 'obj') || hasOwnProperty(property, 'tree') || hasOwnProperty(property, 'type')) {
         propSchema = property
       } else { // schema defined as object
         propSchema = { obj: property, options: {} }
@@ -141,10 +141,10 @@ const getSchemaObject = (schema) => {
 
   if (Array.isArray(schema)) { // if ArrayOfSchema take first item from array
     schemaObj = getSchemaObject(schema[0])
-  } else if (schema.obj) { // take obj
+  } else if (schema.obj || schema.tree) { // take obj
     const additionalFileds = schema.options ? _getOptionFields(schema.options) : {}
 
-    schemaObj = { ...schema.obj, ...additionalFileds }
+    schemaObj = { ...(schema.obj || schema.tree), ...additionalFileds }
   } else if (schema.type) { // get schema inside type
     // NOTE:
     // if you define subschema as type, mongoose doesn't build


### PR DESCRIPTION
During my implementation, I was getting `obj` as undefined in my mongoose schema. I have a property called `tree` which may contain all the necessary information for this parsing. After adding this validation, everything is well detected. 

Please, check the possibility of side effects in this implementation.

Thanks